### PR TITLE
removing lines that contained only a dot

### DIFF
--- a/NTREX-128/newstest2019-ref.wol.txt
+++ b/NTREX-128/newstest2019-ref.wol.txt
@@ -625,7 +625,6 @@ Neena "Altine dina inndil Boliwi ap "saas bu ngannde ngande ngir defaraat diggan
 Calzadilla daa di na weddi ni Morales ba tay ki ëppale ay nit ci persida yu Amerik Latin yi- defa doon jaare ci ay mbiri geej di defaale politik.
 Mu yokk ci ne " Boliwi du musa xaddi xeex ngir am yoon ci geej bu pasifik bi."
 Atte yoon boobu ap saas la ngir ñu xam ni deñoo wara taxxaliko ak sunu dëmb
-.
 Kore bu gannaar xamlena ni niilaal nikaleyeer du am fii ak woolu Amerik amagul
 Jawriñu lu jem ci wallu Bittim rëëw mu Kore Gannaar Ri Yong Ho neena rëëwam du njëkk niilal ngannaayam nikaleyeer fii ak wooluwuñu Amerik.
 Ri mungi doon waxe ci Samdi bii ci asammbale seneraal bu mbootaayu xeet yi.
@@ -636,7 +635,6 @@ Washington defay teey ci naŋngu boobu deggoo te Pyong Yang deul ay jeego ngir n
 Kim ak Amerik yepp. Persida Donald Trump defa bëgg beneen ndaje.
 Waaye nak amna ap sikki sakka bu yaatu ni Pyong Yang fasul yeene bayi ay ngannaay yu takku yoo xamni denuy samm kaaraange rëëw ma.
 Pompeo mungi waaja seeti Pyong yang weer wi jubsi ngir waajal beneen ndaje diggnate KIM-TRUMP.
-.
 Paris fashion shows wonena ay mbir ci solinu bopp ci kaw yoonam bi ci sa wet
 Soo bëgge yokk yaatuwaayu sa mbaxna mbaa nga nacc naaj bi mbul wëri feneen.
 Yooyu ñawkat di Valentino ak Thom Browne gennenañu benn gaamu colinu bopp yu yaatu ba dof ngir seen lal bu SS19 bi ci kaw yoon wi, lu jaaxal waa istil boobu am Paris Fashion.
@@ -652,7 +650,6 @@ Yooyu mbaxna yu yaatu deñuy dall ci taloŋ yu "La Bomba" mbaxna bu ñax boobu a
 Nataalu kilta bu nekk ci ginnaaw mbaxna yu ñu munul jafandiku bi ñu bayi mu late ci reso sosiyoo yi yonnena beneen gaam ci yoon bu xat bi- Saak bu ñagu tefes bu tollu ni yere feeyukaay lammboo ko.
 Saagu oraas bu lakk bi ñu rabbe ak rafiya aki der bu weex moo nekkoon piyees bu jël raw gaddu bu lalup SS19 bu Jacquemus La Riviera ci Paris Fashion Week.
 Istilist bu siiw bii di Luke Armitage waxnaFEMAIL: ''Maangi xaar ngir gis ay mbaxna yu yaatu ak ay saagu tefes ñew ci noor gi jubsi - ginnaaw bi ñawkat bi defee ay jeego yu nganndee nii, komanndu juntuwaay yu yaatu yi du yomb bañ.
-.
 John Edward: Xam ay kallaama lu munul ñakk la ci ay ndawu aduna bi
 Daara bu Ekost bii di moom sa bopp defa des ci jeegoom ci xarañteef, te loolu moo wey ba 2018 ak ay resilta yu baaxa baax ci eksame yi te li ko degaral moy ligeeyu kenn mbaa mboolo ci wallu taggat yaram, aar, misik, ak taxaw temm bu yeneen askan yi.
 Ak luy romb 30.000 ndonngo ci Ekost, yii daara yu Council of Independent Schools yu Ekost (SCIS) deñuy rayante ba joxe ligeey bu gina muccu ayip ci seeni ndonngo ak seeni waajur.
@@ -683,7 +680,6 @@ Konn nak lakk yu mujju yi deñu leen wara jappee ni " xam xamu waxtaan bu jeggi 
 Daara independent dina wey di maye bii tanneef, wute ak xareñteef ngir ndawu Ekost yi.
 Faawu nga def ko bu baax.
 John Edward moy njiitu konsil bu daara independent yu Ekostis
-.
 LeBron wara door ak wa Lakers ci Dibeer ci San Diego
 Soppe yi doon xaar bu yagg ngir gis Lebron tammbale ci bu njëkk ak Los Angeles Lakers xamleen ni jeexna daanaka.
 Anterneer bu Lakers Luke Walton xamlena ni James dina jongante Dimaas ci waajal at bi seen diggante ak Denver Nuggets ci San Diego.
@@ -692,7 +688,6 @@ Walton neena" Dina ëppu benn waaye du matt 48" seen sit ofisel bi.
 Reporteeru Lakers boobu di Mike Trudell bind na ci twitter di xamle ni James ay simili yu nééw rek lay jongante.
 Ni ñu koy faral di defe, ci fan yii ñu genni ci bii ayubes, laaj nañu James lan la nar ak Lakers ci "jiroom benni jongante waajal sesoŋ bi.
 Mu ne "Soxlawuma ay jongante waajal sesoŋ fii ma tollu ci sama kariyeer bi ngir ma pare".
-.
 Waxtu dem bu Trump ci gannaaru Virginia, seenu Yutub
 Persida Donald Trump doorna ap kampaañ ci doole tay ci ngoon aki woto , gannaaru Virginia.
 jiroomi ndaje yi Trump degmal ci ayubes bi, boole ci eskaal ci yenn bërëbu xarit yu mel ni Tennessee ak Mississippi.
@@ -708,7 +703,6 @@ Ndaje bu tay ci guddi bii ñu nara defe ci Wesbanco Arena munna inndi ay jappale
 Samdi mooy doon ñaarelu yoon ci weer wi ñu genni bi Trump deme setsi Virginia bu gannaar , dëkk bi mu daane ak lu ëppu 40 poñ ci teemeer boo jél ci 2016.
 Trump defay jeema jappale mbëru senateer bu Virginia bu Gannaar Patrick Morrisey, mii nekk di suux ci sonndaas yi.
 "Persida ñew di may Morrisey loxo tektalewul lu baax " Simon Haeder , benn waay buy yenngu ci siyaas ci Daara bu Kawe buGannaaru Virginia sunu sukkandikoo ci Reuters".
-.
 Kup bu Ryder 2018: Team USA wonena biir ngir xeexndax ñu muna dunndu ba wote yii di jubsi
 Ginnaaw ñetti sesiyoŋ yu jém benn boor , ñi bari yaakaarnañu ni loolu moy li Ryder Cup bëggoon Samdi ci ngoon.
 Saa boobu di balaas li ñu sos la ci taggat yaram waaye lu jongantekat yi gëm la, te munuñu ko romb ci ay jongante yu mel ni yii.
@@ -733,7 +727,6 @@ Ap bogey ak ñaari yoon ñaar ci kanam moo puus Españool bi ak Suweduwa bi moo 
 Ci Dibeer amul kenn ku lay dimmbali bo nga genni ci sa pax mi.
 ñeenti bal yi ak ñeenti defa neexoon seetaan ci fu jege ndax te ndax lokkaloo bi ci diggante ñaar ñi ñu boole, seen xelal bi ñuy joxe, ak bi ñu joxewul, ak ni ap pexe mune soppeeku ci saas yi.
 Orop gënna jongantena ni ekip fu gina sori ba am njiit bu rafet ci bës bu mujju bi waayi bii ñeent sesiyoŋ moom wonena ni Team USA amna biir bu mu xeexe ci anam bi, rawatina ci TolluwaayRëëw , lu ñu doon sikki sakka la.
-.
 Orop jiituna a 10- 2 ci bës bu mujju ci Ryder Cup
 Orop dina jël ap saas bu sell ci bës bu mujju bi ci Ryder Cup ginnaaw bi mu jugaate Samdi ci ñeenti bal yi ak ñeenti jongante ak 10-6 ci kaw Amerik.
 Tommy Fleetwood ak Francesco Molinari ñi am ñoo ubbi baal bi ak ñaari ndam ci kaw Tiger Woods mi doon wexxu ngir yobbu Le Golf Nasonaal ci ñeenti poñ.
@@ -749,7 +742,6 @@ Gañekatu ñetti yoon yi Jordan Spieth ak Justin Thomas ñoo wone yoon wi ci waa
 Amnañu ndamu 2&1 ci kaw Españool yi dii Jon Rahm ak Ian Poulter ci ñeentibal , ñu dikkaat door Poulter ak Rory McIlroy 4&3 ci foosom yi ginnaaw bi ñu ñakke ñaari pax yi.
 ñaari yoon dong ci taaliifu Ryder cup la benn ekip juge ci ñeent ci ginnaaw deme ko am benn benn bi , te itam ñi ko teye waa ekipu Furyk li ñu bëg du lenn lu moy tëmmboo ngir tëye raaya bi.
 Ginnaaw bi ñu doone ñaarel bu gina baax ci diiru ñaari fan, ab wëlbatiku bu Dibeer meloon na ni xajul ci seen kaw.
-.
 Kore bu gannaar neena “munul nekk” mu summi ngannaay moom dong te anndul ak woolu.
 Jawriñ wallu bittim rëëw bu Kore bu gannaar neena wa Mbootaayu Xeet yi ci Samdi bi ni ay dal ñungi doon wey di gina xootal ñakk woolam ci Amerik te amul fu réew ma di jaar ba muna bayi ngannaayam nikaleyeer ci yooyu anam.
 Ri Yong neena bankaasu att bu Asambale seneraal ni Kore bu gannaar jëlna " matuwaay ci jëf lu baax" ci at yi ñu genni , lu mel ni taxawal nikaleyeer ak natt ay misil, dinndi bërëbu nattuwaayu nikaleyeer bi ak woote ngir ñu baña tasaare ay ngannaayu nikaleyeer ak ay xarale nikaleyeer.
@@ -775,7 +767,6 @@ Pompeo demoon na Kore bu gannaar ñetti yoon renn fi may wax ak yeen, waaye dema
 Mu bayi Pyongyong ci weeru Suliye di wax ni defnañu ay jeego, waaye ay waxtu dong Kore bu Gannaar di ko ŋañ di ko laaj ay laaju ku "niru-banndi."
 Kore bu Gannaar ci benn ndaje ak Moon ngir feeñal benn bërëbu misil ak nikaleyeer su Amerik jëloon matuwaay yu mel noonu."
 Neena Kim newoon na ko " matuwaay yu war yi " mu doon wër moy gaaranti bu kaaraange bu Trump wootewoon ci Singapore ak mu daa di jall ci jaarale yoon diggantam ak Washington.
-.
 Ndonngo yu Harvard di jang ci noppalu bu doy
 Njang mu bees ci Daara bu kawe bu Harvard renn defna ba ndonngam yi ci suuf yepp di gina nelaw ci benn xeex boobu jikko buy magg bi nga xamni moy jannge kafeyin -cawarte ' nitu guddi yepp.
 Ap lekkoon gisna ni ndonngo yi ci daara bu jiitu ci aduna bi xamuñuwoon dara ci ni ñuy toppotoowe seen bopp.
@@ -797,7 +788,6 @@ Raymond So, ku am 19 att waa kaliforñi di jang fisik ak simi dimmbalina janngal
 Neena njang mi defa ubbi ay gëtam te puusnako mu ubbi ap njang ngir mboolem ñi ci dekkuwaay daara bi.
 Beneen jeego bi, mu yaakaar, moy mu laaj ndonngo yi ci suuf yepp ñu topp porgaraam bu mel nii bala ñuy dugguji ci daara yu magg yi.
 Janngalekat Czeisler neena digalnañu ndonngo yi ñu regle benn rewey ngir waxtu tëddi ak yeewu, te xam bu baax loru njeexital yu 'leer bu bula" bi ay ekkara LED ak lep luy leeral di genne, lu muna sanna sa doxin sirkajan mu jur ñakk muna nelaw.
-.
 Livingston 1 - 0 Rangers: Bitu Menga bi moo yobbu gooru Gerrard yi ci suuf
 Rangers alxuwaatna beneen gennup bula yi ndax dugalu Dolly Menga bi poñena ekip bu tas bu Steven Gerrard bi ci daanu bu 1-0 ci Livingston.
 Ibrox yi deñu doon ut seen ndam bu njëkk Feburiye ba leegi ci seen ndam bu 4-1 ci St Johnstone, waaye ekipu Gary Holt bi defa rek jox Gerrard ñaarelu nërmeelam ci 18 matsa bi mu nekke anterneer ba leegi, mu bayi leen ci 8 poñ ci ginnaaw Ladbrokes mii jiite Hearts.
@@ -819,7 +809,6 @@ Gerrard jëemna dara ci xaaj bi ndax gennena Coulibaly tekk Ryan Kent te boobu c
 Waaye Livingston wéy di sonal gan yi di suye xeetu suye yi mu bëg, Lithgow ak Halkett di sanni ball yu guddu rek.
 Ekipu Holt bi munoon na yokk seen njiit ci mujju gi waaye McGregor daa taxaw temm ngir xañ Jacobs bala Lithgow di mbëkk fu sori ci koñ bi.
 Rampalasaa bu Rangers Glenn Middleton amoon na beneen ñaxtu penalti bi mu mbëkkante ak Jacobs waaye Thomson xoolaat ci all ba.
-.
 Almanac: Ki defar kóntóor Geiger
 Leegi ak benn xëtt bu juge ci sunu “Sunday Morning" Almanac: 30 Setammbur ,1882, 136 at ci ginnaaw tay, ak di LIM... bës bi kii wara nekki ap fisisiyen Johannes Wilhelm "Hans" Geiger juddu ci Almaañ.
 Geiger defarna benn anam bu muy gise ak natt ay rajoaktiwite, ap sos bu jur loolu ñuy wowe Kontoor bu Geiger.
@@ -830,7 +819,6 @@ Soo takke yii kaski, dengay dëgg njeexital yii atom yii di def te li ko waral m
 Evans: "Waxal, mungi dox leegi!!"
 "Hans" Geiger mungi faatu ci 1945 ay fan rekka desoon mu agg ci bësam bu dellusi bu 63 yoond.
 Waaye sos bii mu sosoon mu def ci turam mungi fii ba leegi.
-.
 ñakku kañseer bu bees bi munna janngal xarekat yaram yi gis ay selil yu médd
 ñakku kañseer bu bees bi munna janngal xarekat yaram yi gis ay selil yu médd
 ñakku defay janngal xarekatu yaram yi xamme selil yu medd yi ci paj mi la bokk
@@ -842,7 +830,6 @@ Bokk na ci anam yi ñu koy defe, jële ay selilu xeexkat yaram yi ci kuy faju ki
 Janngalekat bii di Jay Berzofsky bu Kurel nasonaal bu Kañseer bu Amerik, Bethesda Maryland neena: “Sunu ay resilta defay wone ni amnañu ñakku bu and ak yaakaar.”
 Janngalekat Berzofsky leeralna ni HER2 mooy “inndi law bu yenn kañseer” yu ci mel ni " bu ween, owariyen, pumoŋ yi ak Kolorectaal.
 App anamu jël ay selilu xeexkat ci fajukat bi, "janngal" leen naka lañuy gatanduwe ay selil yu kañseer doxna ci pajum benn xeetu losemi.
-.
 Kanye West Yooruna ci benn Mbiru Waa-Trump, Sol benn mbaxna MAGA, Ginnaaw bi mu Feeñe ci SNL.
 Doxulwoon bu baax de
 Kanye West deñu kaa yuuxu ci istijoo bi mu daan tëgge Laayf ci Samdi Guddi ci ap ligeey fu mu bakke Amerik. Persida ba pare mu ni dina toogat ci atum 2020.
@@ -870,13 +857,11 @@ Mu yokk ci " ñun itam noonu la".
 Laata mbummbaay bi, woykat rap bi xamlena ci Twitter ni soppina tuuram, di wax ni leegi moom " ki ñu xamewoon Kanye West bu njëkk ba la."
 Du moom moo njëkka soppi tuuram ci woykat yi te defa topp ci tanku Diddy, ñu xame ko itam Puff Daddy, Puffy ak P; Daddy.
 Naataangom woykat rap Snoop Dogg, Snoop Lion moo nekkoon tuuram ni ki noonu kaŋngamu misik bii di Prince defa soppi turam ci ap nafar, konn woykat mii ñu xamewoon Prince.
-.
 Daan ngir Jéema faat ak jamaate ci restoraa bu Belfast
 Benn waay bu am 45 att lañu daan ndax defa doon jéema faat, ginnaaw bi benn ñu jame benn waay ci ap restoraa ci soowu Belfast ci Aljuma.
 Poliis neena mungi ame ci Ballyhackamore
 ii wara defaas dina ñew ci kanamu Masistara yi ci Kuur bu Belfast ci Altine
 Dinañu xoolaat daan yi ci sarwiisu porsekisiyoŋ bu ñepp bokk.
-.
 Estaar Game of the Thrones Kit Harington weddina tooke Ngooro
 Kit Harington ñungi ko xame ci cëram fittkat boobu ni Jon Snow ci filmu dëmb yu HBO yi ci Games of Thrones.
 Waaye akteer bi am 31 att ŋañna bu baax toppandoobu macho hero, mu ni cër yi ñu mel ci tele defay tax xale yi deñuy yaakaar ni deñoo wara naxxari deret ngir ñu may leen cër.
@@ -895,7 +880,6 @@ Akteer bi fësalna lu yaggul ni ddaje ak jabaram bii di Rose moy li daxx ci lu m
 Neena Ci bii mbummbaay la daje ak sama kabar, kon ci lii dina ma may sama njaboot bu ëllëk'.
 Rose moo doon def Ygritte, moom mi soxal Kit mii nekkoon Jon Snow ci wallu mbëggeel, ci filma bii jël raw gaddu bu Emmy.
 Kuupal bi mungi sëy ci 2018 ci suufu njaboot bu Leslie ci Ekost.
-.
 HIV/ Sida: Siin xamlena ay janngaro yu bees 14 ci teemeer boo jél
 Siin fësalna ni amna ap yéeg bu tollu ci 14 ci teemeer boo jël ci askanam ñungi dunndu ak HIV ak Sida.
 Lu ëppu 820000 nit amnañu feebar bi ci réew ma ofisel yu wergu yaram ñoo ko xamle.
@@ -909,7 +893,6 @@ Deñoo xataloon goorjigeen yi ci atu 1997 waaye neenañu xatal askanu borom ñaa
 Ndax lu réew ma jappe ci ay aadam, ay gestu wone nañu ni 70-90% ci goor yi di tëdde ay goor, jigeen lañuy takki.
 Lu bari ci wallante yooyu jangaro mungi joge ci ay fagaru yu jaarul yoon ci yooyu and.
 Lu ko dale 2003, nguur bu Siin digewoon na maye ay garabu HIV mu doon ap jeego ngir xeex ak boobu tolof tolof.
-.
 Maxine Waters weddina bindkat bi sacc GOP ay moomel yu senateer yi, ap riir , 'fen yu bon' aki kacc.'
 AmeriK Rep. Maxine Waters Ci Dibeer ñaawluna wax jooju di biral ni kenn ci ay nitam gennena ay moomel yu ñetti senateer Repibilikeen yu Amerik yi ci Siis ba ' Xët yu Wikipedia.
 Demokaraat yu Los Angeles yi neenañu njabbat yi ay xalaatkat ak situ enternet waa “ci ndey joor gi” ñoo ko jiite.
@@ -933,7 +916,6 @@ Omar Navarro, benn mbër Repinilikeen mii di fexe ngir daanel Waters ci wote dig
 "Lu rëy su nekke dëgg” la bind ci twitter.
 Ci biir kominike am ba, Waters neena biroo am bi artuwoon na " ci njiit yi ak bankaas yu teralinu yoon ci jooytu yu jaarul yoon dara.
 Dinañu ci taxaw temmbe ngir ñii ko def fee" mu yokk ci " te dinañu leen jappee ni ñoom ñnn tey jëf yooyu jëf yu ñaaw yuy yaxxaate te bon ci ku nekkak ñii bokk ci sama ligeeykat yepp.
-.
 Johnny English dooraatna xoolaat- mu nééwal Rowan Atkinson, di yuurnu.
 Leegi seet lu Brexit tekki ci beppu filma bu am dara lu laal Biritaañ nekkaatna ap mbaax te loolu defa mel ni am ci dekki bu tiyataar yu Johnny English - bi tammbali ci 2003 ak Johnny English muu daa di fëllaat ci 2011 ak judduwaat bu Johnny English.
 Ndax lammiñ bi nekk ci biir gemmiñ dina atte boppam ci tem boobu di ni ñu nekke ay walakaana ngir doon saasu defaral réewmi?
@@ -957,7 +939,6 @@ Waa Anngalteer ak Bough tammbali seen odise boobu pentiir-kanam, degisewu ni ay 
 Estop yep dina feeñ ci beneen pacc mu mujju bi , waaye ni mu neexe ak amna tuuti ay tele xale ci afeer bi yepp.
 Ay mbir yu yemmamaay.
 Ni yeneeni filma yu English rek, munumawoon baña xalaat: ndax koomu Biritaañ munul jox Rowan Atkinson benn cër bu mënngoo ak xarañteefam.
-.
 Labour weddina ni defay lal benn pexe ngir Britons yi di ligeey ñeenti fan ci ayubes waaye di feyeeku jiroomi fan.
 Parti Labour bu Corbyn mungi waaja lal benn pexe boo xamni dina tax Britons yi ligeey ñeenti fan ci ayubes -waaye feyeeku jiroom.
 Neenañu parti bi defa bëgg boroom sosete yi ngir ñu genne ndenc yi ñu defe juntuwaay yu bees yi (AI) coppite su leen joxe ben bës dallu.
@@ -973,7 +954,6 @@ Sanseliye bu Shadow John McDonnell defa jél ndaje bu Labour ci ayubes bi ñu ge
 McDonnel neena defa fasuwoon ngir tibbaat nguur ci 'njiitu yu ñakk yermaande' ak ' nitu entere yi' ci kurelu feexuwaay.
 Ay pexe yu Sanseliye Shadow bi moy borom alal yu ñu bokk ci ndox mi munnañu baña jotaat seen yëf ndax te nguuru Labour bi munna def ay 'dag' ci kaw suuf yi defkatuay yi jot.
 Moom firndeelna itam ay pexe ngir tek ligeeykat yi sosete yi ak defar ay moomel yu ñu bëgg ngir japp ci 10 ci teemeer boo jël ci sekteer piriwe, yamale ligeeykat yi ñii di taxaw ngir dugal £500 ci seen poos ci at bi.
-.
 Lindsey Graham, John Kennedy neena “60 Simili” ndax lalaŋketu FBI bu Kavanaugh bi munna soppi seen xalaat.
 Laŋketu FBI bi ci tuuma yi tegu ci ndoddu Attekat Brett Kavanaugh moo yeexal wote bu mujju bi ci falam ci Kuur BU kawe bi fii ak ayubes; mu yekketi laaj ndax li biro bi fekk dina tax kenn ci senateeru repibilikeen yi inndi ndimmbalam.
 Ci benn waxtoon ak ndawu Sunday 60 Minutes laaj na senateer repibilikeen yi. John Kennedy ak Lindsey Graham su de FBI dina muna sulli dara lu leen wara taxa soppi seen xel.
@@ -988,7 +968,6 @@ Neena" Jélnaa sama desisoŋ bu jém ci Brett Kavanaugh ba pare te dina jél tuu
 "Te munuñwoon firnde ñi mu waxoon ñepp.
 36 att la."
 Gisuma fii lenn lu bees lu soppeeku."
-.
 Lan moy Festiwaalu ndawu askan wi ndax defna dara luy waññi ñakk gi?
 Bii Samdi New York dina dalal Festiwaal bu Ndawi aduna , ap xew xewu misik buy dajale ay estaar te xemmemteefam moy jeexal ñakk ci aduna bi.
 Leegi ci jiroom ñaarelu atam, Festiwaalu Ndawi Askan widina dalal ak fukki junni junni, nit yu jëm central Paek Great Lawn, yemul rek ci topp ay jëf lu mel ni Janet Jackson, Cardi B ak Shawn Mendes waaye itam ngir yeete ci lu taxa xaw bi jog ci dégg dégg moy dinndi ñakk bu baax bala 2030.
@@ -1007,7 +986,6 @@ Ngir tontu benn ci laaj ak tontu yi, ci sitam enternet " Lan moo tax nga xalaat 
 Ndawu askan wi tontu: App yoon bu guddu te yagg lool lay doon- yenn saa yi dinañu lajj, lajj;
 Waaye , ni yoonu siwil bu magg bi ak xeex-apartayid bala sunu juddu, dinañu tekki de , ndax te mboolo moy sunu doole;
 Janet Jackson, wiken bi, Shawn Mendes, Cardi B, Janelle Monae book nañu renn ci ñii moom jëf yi ci xew bu amoon New York, bi nga xam ni Deborra-Lee moo koy def;
-.
 Amerik munna jefandikoo Navy ngir "bolokaas" ndax xajamal yobbu bi Risi di yobbu enersi- Sekkerteer bu Enteriyeer
 Sekkerteer bu Enteriyeer bu Amerik Ryan Zinke neena Washington munna "su ko jare" dellu ci Navy bi ngir tere enersi bu Risi bi wacc marse bi, boole ci moyenoriaan bi, , ni ko Washington Examiner birale.
 Zinker tuumalna Risi ni nekkam bii ci Siri rawatina fii muy xéy, ap laxxuwaay la rek ngir tibb ci marse enersi yu bees.


### PR DESCRIPTION
The `NTREX-128/newstest2019-ref.wol.txt` file contained lines with only a dot as content which broke the alignment with the English source. The file contained 2019 lines and I cleaned up the artifacts to restore the alignment and it now contains 1997 lines and is well aligned with the source.